### PR TITLE
fix(light): remove dangling skills path from plugin.json

### DIFF
--- a/editions/light/plugin/.claude-plugin/plugin.json
+++ b/editions/light/plugin/.claude-plugin/plugin.json
@@ -26,7 +26,6 @@
   },
   "commands": "./.claude/commands",
   "agents": "./.claude/agents",
-  "skills": "./.claude/skills",
   "settings": "./.claude/settings.json",
   "engines": {
     "claude-code": ">=1.0.0",


### PR DESCRIPTION
The light plugin declared `"skills": "./.claude/skills"` but that directory does not exist (light is BOOT-file based, no bundled skills). Removed the dangling reference so plugin install/load does not point at a missing path. Commands + agents unaffected.