### PR TITLE
fix(skill): add name+description frontmatter to main p2p SKILL.md

### DIFF
--- a/editions/cloud-claude/plugin/.claude/skills/p2p/SKILL.md
+++ b/editions/cloud-claude/plugin/.claude/skills/p2p/SKILL.md
@@ -1,4 +1,6 @@
 ---
+name: p2p
+description: P2P v8C.3-ALPHA — main Skill entry point of the Prompt-to-Prompt meta-prompt system for Claude. Use when the user types /p2p, /start, старт, or /menu, or asks to build/generate/optimize a prompt, run a QUORUM multi-agent review, SCOPE.HELM scoping, or any /p2p-* workflow. Entry point and main menu for the P2P system. Not for the interactive course (use p2p-teacher).
 source_id: SKILL_V8C
 version: v8C.3-ALPHA
 module_type: skill


### PR DESCRIPTION
The main `p2p` skill manifest used `scope:` but lacked the standard `name:`/`description:` frontmatter (its sibling `p2p-teacher` skill has them). Stricter Claude Code versions need `name`+`description` to discover/auto-trigger a skill; without them it only loaded via H1-title fallback. Added both (kept existing fields). This is the system's entry-point skill, so robust loading matters.