### PR TITLE
fix(plugin): make plugin.json schema-valid (fixes marketplace install failure)

### DIFF
--- a/editions/cloud-claude/plugin/.claude-plugin/plugin.json
+++ b/editions/cloud-claude/plugin/.claude-plugin/plugin.json
@@ -20,20 +20,17 @@
   ],
   "license": "MIT",
   "homepage": "https://github.com/sanic732/P2P-4PDA-edition",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/sanic732/P2P-4PDA-edition.git"
-  },
-  "commands": "./.claude/commands",
-  "agents": "./.claude/agents",
-  "skills": "./.claude/skills",
-  "settings": "./.claude/settings.json",
+  "repository": "https://github.com/sanic732/P2P-4PDA-edition.git",
   "engines": {
     "claude-code": ">=1.0.0",
     "cowork": ">=0.1.0"
   },
   "compatibility": {
-    "platforms": ["claude-code", "cowork", "claude-app"],
+    "platforms": [
+      "claude-code",
+      "cowork",
+      "claude-app"
+    ],
     "models": [
       "claude-opus-4-7",
       "claude-sonnet-4-6",

--- a/editions/light/plugin/.claude-plugin/plugin.json
+++ b/editions/light/plugin/.claude-plugin/plugin.json
@@ -20,19 +20,17 @@
   ],
   "license": "MIT",
   "homepage": "https://github.com/sanic732/P2P-4PDA-edition",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/sanic732/P2P-4PDA-edition.git"
-  },
-  "commands": "./.claude/commands",
-  "agents": "./.claude/agents",
-  "settings": "./.claude/settings.json",
+  "repository": "https://github.com/sanic732/P2P-4PDA-edition.git",
   "engines": {
     "claude-code": ">=1.0.0",
     "cowork": ">=0.1.0"
   },
   "compatibility": {
-    "platforms": ["claude-code", "cowork", "claude-app"],
+    "platforms": [
+      "claude-code",
+      "cowork",
+      "claude-app"
+    ],
     "models": [
       "claude-fable-5",
       "claude-opus-4-8",


### PR DESCRIPTION
## Root cause
Marketplace install failed with `invalid manifest file ...plugin.json`. Both plugin.json files violated the official `claude-code-plugin-manifest` schema in 3 ways:

| field | was | schema requires |
|---|---|---|
| `settings` | string path | object |
| `repository` | object {type,url} | string |
| `agents` | dir path string | file path or array |

## Fix
- `repository` → string URL
- remove `settings` (settings.json auto-loaded)
- remove `commands`/`agents`/`skills` path declarations (auto-discovered from `.claude/`)
- Validated both manifests against the schema: **0 errors**

Latent since 8.3.0 — marketplace install never worked; only Local-uploads path (looser validation) did.