### PR TITLE
fix(plugin): restore commands/agents/skills (agents as file array)

### DIFF
--- a/editions/cloud-claude/plugin/.claude-plugin/plugin.json
+++ b/editions/cloud-claude/plugin/.claude-plugin/plugin.json
@@ -21,6 +21,18 @@
   "license": "MIT",
   "homepage": "https://github.com/sanic732/P2P-4PDA-edition",
   "repository": "https://github.com/sanic732/P2P-4PDA-edition.git",
+  "commands": "./.claude/commands",
+  "agents": [
+    "./.claude/agents/p2p-anon.md",
+    "./.claude/agents/p2p-architecton.md",
+    "./.claude/agents/p2p-axiom.md",
+    "./.claude/agents/p2p-datos.md",
+    "./.claude/agents/p2p-helios.md",
+    "./.claude/agents/p2p-iris.md",
+    "./.claude/agents/p2p-tecton.md",
+    "./.claude/agents/p2p-vector.md"
+  ],
+  "skills": "./.claude/skills",
   "engines": {
     "claude-code": ">=1.0.0",
     "cowork": ">=0.1.0"

--- a/editions/light/plugin/.claude-plugin/plugin.json
+++ b/editions/light/plugin/.claude-plugin/plugin.json
@@ -21,6 +21,17 @@
   "license": "MIT",
   "homepage": "https://github.com/sanic732/P2P-4PDA-edition",
   "repository": "https://github.com/sanic732/P2P-4PDA-edition.git",
+  "commands": "./.claude/commands",
+  "agents": [
+    "./.claude/agents/p2p-anon.md",
+    "./.claude/agents/p2p-architecton.md",
+    "./.claude/agents/p2p-axiom.md",
+    "./.claude/agents/p2p-datos.md",
+    "./.claude/agents/p2p-helios.md",
+    "./.claude/agents/p2p-iris.md",
+    "./.claude/agents/p2p-tecton.md",
+    "./.claude/agents/p2p-vector.md"
+  ],
   "engines": {
     "claude-code": ">=1.0.0",
     "cowork": ">=0.1.0"


### PR DESCRIPTION
Previous manifest fix over-removed `commands`/`agents`/`skills`, so the GUI showed 'no skills or agents'. Restored: `commands` (dir string), `skills` (dir string, cloud), `agents` as ARRAY of 8 .md files (schema requires .md file paths; a directory string is invalid). Both manifests validate against the official schema with 0 errors. GUI now lists 11 commands / 8 agents / 2 skills.