### PR TITLE
Remove Light from marketplace — fix command prefix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "p2p",
   "displayName": "P2P Marketplace — 4PDA Edition",
-  "description": "Official P2P meta-prompt system marketplace (Claude Native + Lite editions, mirror published for the 4PDA community)",
+  "description": "Official P2P meta-prompt system marketplace (Claude Native edition, mirror published for the 4PDA community)",
   "owner": { "name": "sanic732", "email": "sanic732@gmail.com" },
   "homepage": "https://github.com/sanic732/P2P-4PDA-edition",
   "repository": { "type": "git", "url": "https://github.com/sanic732/P2P-4PDA-edition.git" },
@@ -13,13 +13,6 @@
       "description": "P2P v8C.3-ALPHA Claude Edition — PILOT/SHERPA, 6 ON-DEMAND modules, 8 QUORUM agents, 11 commands, XML-native, SCOPE.HELM",
       "tags": ["latest", "alpha", "claude-native"],
       "version": "8.3.2-C"
-    },
-    {
-      "name": "p2p-v8l3",
-      "source": "./editions/light/plugin",
-      "description": "P2P v8L.3-ALPHA Lite/Live Edition — 4 BOOT files + lazy online fetch, universal host",
-      "tags": ["lite", "live", "alpha"],
-      "version": "8.3.1"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Removed `p2p-v8l3` from root `marketplace.json` — leaves only `p2p-v8c3`
- Fixes long command prefixes: `p2p-v8c3:p2p-quorum` → `p2p-quorum`
- Light edition stays in the repo and release as a standalone `.plugin` file

## Why
Two plugins in one marketplace caused Claude Code to namespace all commands/skills/agents with the plugin ID prefix for disambiguation. One plugin = no prefix needed.

## Test plan
- [ ] Reinstall plugin from marketplace after merge
- [ ] Verify commands show without `p2p-v8c3:` prefix in palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)