### PR TITLE
release: P2P v8.3.6 (Update for all users)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,15 +11,13 @@
       "name": "p2p-v8c3",
       "source": "./editions/claude-native/plugin",
       "description": "P2P v8C.3-BETA Claude Native Edition — PILOT/SHERPA, 6 ON-DEMAND modules, 8 QUORUM agents, 11 commands, XML-native, SCOPE.HELM",
-      "tags": ["latest", "beta", "claude-native"],
-      "version": "8.3.5"
+      "tags": ["latest", "beta", "claude-native"]
     },
     {
       "name": "p2p-v8l3",
       "source": "./editions/light/plugin",
       "description": "P2P v8L.3-BETA Lite/Live Edition — 4 BOOT files + lazy online fetch, universal host",
-      "tags": ["lite", "live", "beta"],
-      "version": "8.3.5"
+      "tags": ["lite", "live", "beta"]
     }
   ]
 }

--- a/editions/claude-native/plugin/.claude-plugin/plugin.json
+++ b/editions/claude-native/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "p2p-v8c3",
   "displayName": "P2P v8C.3 — Claude Native Edition",
-  "version": "8.3.5",
+  "version": "8.3.6",
   "description": "Meta-prompt system for Claude Opus 4.7 / Sonnet 4.6. 8 QUORUM agents, 11 /p2p-* commands, XML-native, SCOPE.HELM, interactive teacher mode.",
   "author": {
     "name": "P2P Project"

--- a/editions/claude-native/plugin/pack.ps1
+++ b/editions/claude-native/plugin/pack.ps1
@@ -1,50 +1,76 @@
-# pack.ps1 — Упаковка P2P v8C.2 в .plugin файл для one-click импорта
+# pack.ps1 — Build a .plugin bundle of the Claude-Native edition (version-agnostic).
+#
+# WHAT THIS IS (and is NOT):
+#   • The .plugin file is a ZIP of THIS single plugin folder, for MANUAL import only
+#     (Cowork → "Upload a skill", or a one-off local install). It bundles ONE plugin.
+#   • It is NOT how the marketplace works. "Add marketplace → Sync" clones the whole
+#     repo and reads .claude-plugin/marketplace.json (at the REPO ROOT); each plugin is
+#     fetched from its `source`. This script does not touch that flow.
+#
+# VERSIONING: the bundle name and version are read LIVE from .claude-plugin/plugin.json,
+#   so the script is never tied to a hardcoded version — it always packs the latest manifest.
+#   Output name defaults to "<plugin name>.plugin" (e.g. p2p-v8c3.plugin).
+#
 # Usage: powershell -ExecutionPolicy Bypass -File pack.ps1 [output_name]
-# Default output: p2p-v8c2.plugin
 
 param(
-    [string]$OutputName = "p2p-v8c2.plugin"
+    [string]$OutputName
 )
 
 $ErrorActionPreference = "Stop"
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$OutputPath = Join-Path (Split-Path -Parent $ScriptDir) $OutputName
 
-Write-Host "═══════════════════════════════════════════════════════════"
-Write-Host "  P2P v8C.2 PACKAGING SCRIPT (PowerShell)"
-Write-Host "═══════════════════════════════════════════════════════════"
-Write-Host "  Source:  $ScriptDir"
-Write-Host "  Output:  $OutputPath"
-Write-Host "═══════════════════════════════════════════════════════════"
-
-# Validate plugin.json
+# --- Read & validate plugin.json (single source of truth for name + version) ---
 $PluginManifest = Join-Path $ScriptDir ".claude-plugin\plugin.json"
 if (-not (Test-Path $PluginManifest)) {
     Write-Error "plugin.json not found at $PluginManifest"
     exit 1
 }
-
-# Validate JSON parses
 try {
-    Get-Content $PluginManifest -Raw | ConvertFrom-Json | Out-Null
+    $Manifest = Get-Content $PluginManifest -Raw | ConvertFrom-Json
 } catch {
     Write-Error "plugin.json is not valid JSON: $_"
     exit 1
 }
+if (-not $Manifest.name) {
+    Write-Error "plugin.json has no 'name' field"
+    exit 1
+}
+
+$PluginName = $Manifest.name
+$PluginVer  = if ($Manifest.version) { $Manifest.version } else { "(unset → commit-SHA versioning)" }
+if (-not $OutputName) { $OutputName = "$PluginName.plugin" }
+$OutputPath = Join-Path (Split-Path -Parent $ScriptDir) $OutputName
+
+# --- Guard: a plugin folder must NOT contain its own marketplace.json (nested-marketplace bug) ---
+$NestedMarketplace = Join-Path $ScriptDir ".claude-plugin\marketplace.json"
+if (Test-Path $NestedMarketplace) {
+    Write-Error "Nested marketplace.json found inside the plugin ($NestedMarketplace). marketplace.json must live ONLY at the repo root, not inside a plugin."
+    exit 1
+}
+
+Write-Host "═══════════════════════════════════════════════════════════"
+Write-Host "  P2P PLUGIN PACKAGING (version-agnostic)"
+Write-Host "═══════════════════════════════════════════════════════════"
+Write-Host "  Plugin:   $PluginName"
+Write-Host "  Version:  $PluginVer"
+Write-Host "  Source:   $ScriptDir"
+Write-Host "  Output:   $OutputPath"
+Write-Host "═══════════════════════════════════════════════════════════"
 
 # Remove old output
 if (Test-Path $OutputPath) { Remove-Item $OutputPath -Force }
 
-# Build temporary staging directory excluding pack scripts and .plugin files
-$TempDir = Join-Path $env:TEMP "p2p-v8c2-pack-$(Get-Random)"
+# --- Stage everything except packaging artifacts ---
+$Excludes = @('.git', '.DS_Store', 'node_modules', '*.plugin', 'pack.sh', 'pack.ps1')
+$TempDir = Join-Path $env:TEMP "p2p-pack-$(Get-Random)"
 New-Item -ItemType Directory -Path $TempDir | Out-Null
 
 try {
-    # Copy everything except excluded patterns
     Get-ChildItem -Path $ScriptDir -Recurse -Force | ForEach-Object {
         $RelPath = $_.FullName.Substring($ScriptDir.Length + 1)
         $skip = $false
-        foreach ($pattern in @('.git', '.DS_Store', 'node_modules', '*.plugin', 'pack.sh', 'pack.ps1')) {
+        foreach ($pattern in $Excludes) {
             if ($RelPath -like "*$pattern*") { $skip = $true; break }
         }
         if (-not $skip) {
@@ -59,22 +85,36 @@ try {
         }
     }
 
+    # Sanity: staged plugin.json must still be the manifest we read
+    $StagedManifest = Join-Path $TempDir ".claude-plugin\plugin.json"
+    if (-not (Test-Path $StagedManifest)) {
+        Write-Error "Staging failed: plugin.json missing from staged tree"
+        exit 1
+    }
+
     # Create archive (.plugin = renamed .zip; Compress-Archive requires .zip extension)
     $ZipPath = [System.IO.Path]::ChangeExtension($OutputPath, ".zip")
     if (Test-Path $ZipPath) { Remove-Item $ZipPath -Force }
     Compress-Archive -Path "$TempDir\*" -DestinationPath $ZipPath -CompressionLevel Optimal -Force
     Rename-Item -Path $ZipPath -NewName (Split-Path -Leaf $OutputPath)
 
+    $FileCount = (Get-ChildItem -Path $TempDir -Recurse -File).Count
+    $SizeKB = [Math]::Round((Get-Item $OutputPath).Length / 1KB, 1)
+
     Write-Host ""
     Write-Host "✅ DONE" -ForegroundColor Green
-    $Size = (Get-Item $OutputPath).Length
-    $SizeKB = [Math]::Round($Size / 1KB, 1)
-    Write-Host "   Size:  $SizeKB KB"
-    Write-Host "   Path:  $OutputPath"
+    Write-Host "   Bundle: $OutputName"
+    Write-Host "   Files:  $FileCount"
+    Write-Host "   Size:   $SizeKB KB"
     Write-Host ""
-    Write-Host "Install:"
+    Write-Host "This bundle is for MANUAL import only:"
     Write-Host "  • Cowork:      Settings → Skills → Upload a skill → $OutputName"
     Write-Host "  • Claude Code: /plugin install `"$OutputPath`""
+    Write-Host ""
+    Write-Host "For normal distribution use the MARKETPLACE (no bundle needed):"
+    Write-Host "  • /plugin marketplace add sanic732/P2P-4PDA-edition"
+    Write-Host "  • /plugin install $PluginName@P2P-4PDA-edition"
+    Write-Host "  • Update later: /plugin marketplace update P2P-4PDA-edition"
     Write-Host "═══════════════════════════════════════════════════════════"
 
 } finally {

--- a/editions/claude-native/plugin/pack.sh
+++ b/editions/claude-native/plugin/pack.sh
@@ -1,32 +1,51 @@
 #!/usr/bin/env bash
-# pack.sh — Упаковка P2P v8C.2 в .plugin файл для one-click импорта
+# pack.sh — Build a .plugin bundle of the Claude-Native edition (version-agnostic).
+#
+# WHAT THIS IS (and is NOT):
+#   • The .plugin file is a ZIP of THIS single plugin folder, for MANUAL import only
+#     (Cowork → "Upload a skill", or a one-off local install). It bundles ONE plugin.
+#   • It is NOT how the marketplace works. "Add marketplace → Sync" clones the whole
+#     repo and reads .claude-plugin/marketplace.json (at the REPO ROOT); each plugin is
+#     fetched from its `source`. This script does not touch that flow.
+#
+# VERSIONING: name + version are read LIVE from .claude-plugin/plugin.json, so the
+#   script is never tied to a hardcoded version. Output defaults to "<name>.plugin".
+#
 # Usage: bash pack.sh [output_name]
-# Default output: p2p-v8c2.plugin
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-OUTPUT_NAME="${1:-p2p-v8c2.plugin}"
+MANIFEST="${SCRIPT_DIR}/.claude-plugin/plugin.json"
+
+# --- Read & validate plugin.json (single source of truth for name + version) ---
+if [[ ! -f "${MANIFEST}" ]]; then
+  echo "ERROR: .claude-plugin/plugin.json not found"; exit 1
+fi
+if ! command -v python3 &> /dev/null; then
+  echo "ERROR: python3 required to read plugin.json"; exit 1
+fi
+python3 -c "import json; json.load(open('${MANIFEST}'))" \
+  || { echo "ERROR: plugin.json is not valid JSON"; exit 1; }
+
+PLUGIN_NAME="$(python3 -c "import json; print(json.load(open('${MANIFEST}'))['name'])")"
+PLUGIN_VER="$(python3 -c "import json; print(json.load(open('${MANIFEST}')).get('version','(unset → commit-SHA versioning)'))")"
+OUTPUT_NAME="${1:-${PLUGIN_NAME}.plugin}"
 OUTPUT_PATH="${SCRIPT_DIR}/../${OUTPUT_NAME}"
 
-echo "═══════════════════════════════════════════════════════════"
-echo "  P2P v8C.2 PACKAGING SCRIPT"
-echo "═══════════════════════════════════════════════════════════"
-echo "  Source:  ${SCRIPT_DIR}"
-echo "  Output:  ${OUTPUT_PATH}"
-echo "═══════════════════════════════════════════════════════════"
-
-# Validate plugin.json exists
-if [[ ! -f "${SCRIPT_DIR}/.claude-plugin/plugin.json" ]]; then
-  echo "ERROR: .claude-plugin/plugin.json not found"
-  exit 1
+# --- Guard: a plugin folder must NOT contain its own marketplace.json ---
+if [[ -f "${SCRIPT_DIR}/.claude-plugin/marketplace.json" ]]; then
+  echo "ERROR: nested marketplace.json inside the plugin. It must live ONLY at the repo root."; exit 1
 fi
 
-# Validate JSON parses
-if command -v python3 &> /dev/null; then
-  python3 -c "import json; json.load(open('${SCRIPT_DIR}/.claude-plugin/plugin.json'))" \
-    || { echo "ERROR: plugin.json is not valid JSON"; exit 1; }
-fi
+echo "═══════════════════════════════════════════════════════════"
+echo "  P2P PLUGIN PACKAGING (version-agnostic)"
+echo "═══════════════════════════════════════════════════════════"
+echo "  Plugin:   ${PLUGIN_NAME}"
+echo "  Version:  ${PLUGIN_VER}"
+echo "  Source:   ${SCRIPT_DIR}"
+echo "  Output:   ${OUTPUT_PATH}"
+echo "═══════════════════════════════════════════════════════════"
 
 # Remove old output
 [[ -f "${OUTPUT_PATH}" ]] && rm -f "${OUTPUT_PATH}"
@@ -44,10 +63,15 @@ zip -r "${OUTPUT_PATH}" . \
 
 echo ""
 echo "✅ DONE"
-echo "   Size:  $(du -h "${OUTPUT_PATH}" | cut -f1)"
-echo "   Files: $(unzip -l "${OUTPUT_PATH}" 2>/dev/null | tail -1 | awk '{print $2}')"
+echo "   Bundle: ${OUTPUT_NAME}"
+echo "   Size:   $(du -h "${OUTPUT_PATH}" | cut -f1)"
+echo "   Files:  $(unzip -l "${OUTPUT_PATH}" 2>/dev/null | tail -1 | awk '{print $2}')"
 echo ""
-echo "Install:"
+echo "This bundle is for MANUAL import only:"
 echo "  • Cowork:      Settings → Skills → Upload a skill → ${OUTPUT_NAME}"
 echo "  • Claude Code: /plugin install ${OUTPUT_PATH}"
+echo ""
+echo "For normal distribution use the MARKETPLACE (no bundle needed):"
+echo "  • /plugin marketplace add sanic732/P2P-4PDA-edition"
+echo "  • /plugin install ${PLUGIN_NAME}@P2P-4PDA-edition"
 echo "═══════════════════════════════════════════════════════════"

--- a/editions/light/plugin/.claude-plugin/plugin.json
+++ b/editions/light/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "p2p-v8l3",
   "displayName": "P2P v8L.3 — Lite/Live Hybrid (Universal)",
-  "version": "8.3.5",
+  "version": "8.3.6",
   "description": "Universal (any-host) Lite/Live Hybrid meta-prompt system. Pick host on start: claude|gemini|gpt|grok|deepseek|qwen|kimi|glm. 4 local BOOT files (~18K idle) + 11 lazy Gist chunks fetched on-trigger via a dependency-resolver with sha256 integrity. FETCH-capability gate with honest LITE_ONLY fallback. 8 QUORUM agents (native sub-agents on Claude/Grok, simulated via CORE_PLUS chunk elsewhere). XML emitted only when host=claude.",
   "author": {
     "name": "P2P Project",


### PR DESCRIPTION
Bumps both editions to 8.3.6 so the Update button lights up for all marketplace users.

## Changes
- **plugin.json** `8.3.5 → 8.3.6` for `p2p-v8c3` + `p2p-v8l3` (version bump = update trigger)
- **marketplace.json**: removed duplicate `version` from plugin entries — version now lives only in `plugin.json` (single source of truth, per official docs)
- **pack.ps1 / pack.sh**: version-agnostic (read name/version from plugin.json), nested-marketplace guard, clearer messaging

## Validation
- Load simulation: 0 errors (2 plugins resolve; 8 agents + 11/15 commands + 8 skills present; frontmatter parses)
- Privacy: no original gmail anywhere; commit identity = protonmail
- Strict SemVer (no letter suffixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)