### PR TITLE
fix(high,normal): шаблонный STARTUP_LOGO + снятие ALPHA (8H.3/8N.3)

### DIFF
--- a/editions/high/files/!!core_v8H.md
+++ b/editions/high/files/!!core_v8H.md
@@ -5,7 +5,7 @@ type: CORE
 priority: CRITICAL
 load_order: 2
 compatible_with: "_preloader.md | all v8H files"
-last_verified: 2026-06-17
+last_verified: 2026-06-27
 ---
 
 // ═══════════════════════════════════════════════════════
@@ -204,7 +204,9 @@ SIGNAL_TO_NOISE_PROTOCOL:
 ██╔═══╝  ██╔═══╝  ██╔═══╝ 
 ██║      ███████╗ ██║     
 ╚═╝      ╚══════╝ ╚═╝     
-P2P v8H.3- HIGH EDITION | LiveSpecs: 2026-06-12
+P2P v8H.3- HIGH EDITION
+LiveSpecs: {LIVE_SPECS_DATE}
+HOST: {HOST_MODEL} | MODE: {LOAD_MODE}
 ```
 
 Затем — СРАЗУ единое меню (арты режимов вверху + полный список [1-40]). ОДИН экран, без отдельной витрины.
@@ -218,10 +220,10 @@ P2P v8H.3- HIGH EDITION | LiveSpecs: 2026-06-12
 
 ---
 
-# МЕНЮ P2P v8H.3-ALPHA  (на `/start`, `старт`, `/p2p`, `/menu`, `full ui menu` — ВСЕГДА целиком)
+# МЕНЮ P2P v8H.3  (на `/start`, `старт`, `/p2p`, `/menu`, `full ui menu` — ВСЕГДА целиком)
 
 ```
-⭕ P2P 8H.3-ALPHA — HIGH EDITION
+⭕ P2P 8H.3 — HIGH EDITION
 
 🔰 ОСНОВНЫЕ РЕЖИМЫ:
 1.  🏛️ QUORUM (The Council)
@@ -267,7 +269,7 @@ P2P v8H.3- HIGH EDITION | LiveSpecs: 2026-06-12
 30. 🔄 CONSTRAINT REINJECTION — Авто-переинъекция каждые 25 сообщений
 === ДОКУМЕНТАЦИЯ И ОБУЧЕНИЕ ===
 31. СТАРТ (быстрый старт)
-32. Что нового в v8H.3-ALPHA
+32. Что нового в v8H.3
 33. Полная документация (docs/)
 34. 🎓 ОБУЧЕНИЕ (/p2p-teacher — интерактивный 5-уровневый curriculum)
 34a. 📦 /p2p-download — ПОЛНАЯ ИНТЕГРАЦИЯ: LIVE SPECS (требует web-fetch)
@@ -610,7 +612,7 @@ CORE_RULES:
     - Добавлять >7 MUST/MUST NOT пар для GPT цели (G9)
     - Обращаться к GLM с >100K контекстом (G19)
 
-  [DEADLINE STATUS — 2026-06-17]:
+  [DEADLINE STATUS — 2026-06-27]:
     PASSED 2026-06-15: Claude dated legacy aliases ретайрнуты → claude-opus-4-8/4-7, claude-sonnet-4-6
     PASSED 2026-06-05: gpt-5.x legacy → gpt-5.5
     ACTIVE 2026-07-24: deepseek-chat → deepseek-v4-pro | deepseek-reasoner → deepseek-v4-flash

--- a/editions/normal/files/!!core_v8N.md
+++ b/editions/normal/files/!!core_v8N.md
@@ -5,7 +5,7 @@ type: CORE
 priority: CRITICAL
 load_order: 2
 compatible_with: "_preloader.md | all v8N files"
-last_verified: 2026-06-17
+last_verified: 2026-06-27
 ---
 
 // ═══════════════════════════════════════════════════════
@@ -204,7 +204,8 @@ SIGNAL_TO_NOISE_PROTOCOL:
 ██║      ███████╗ ██║     
 ╚═╝      ╚══════╝ ╚═╝     
 P2P v8N.3 - NORMAL EDITION 
-LiveSpecs: 2026-06-12
+LiveSpecs: {LIVE_SPECS_DATE}
+HOST: {HOST_MODEL} | MODE: {LOAD_MODE}
 ```
 
 Затем — СРАЗУ единое меню (арты режимов вверху + полный список [1-31]). ОДИН экран, без отдельной витрины.
@@ -559,7 +560,7 @@ CORE_RULES:
     - Добавлять >7 MUST/MUST NOT пар для GPT цели (G9)
     - Обращаться к GLM с >100K контекстом (G19)
 
-  [DEADLINE STATUS — 2026-06-17]:
+  [DEADLINE STATUS — 2026-06-27]:
     PASSED 2026-06-15: Claude dated legacy aliases ретайрнуты → claude-opus-4-8/4-7, claude-sonnet-4-6
     PASSED 2026-06-05: gpt-5.x legacy → gpt-5.5
     ACTIVE 2026-07-24: deepseek-chat → deepseek-v4-pro | deepseek-reasoner → deepseek-v4-flash


### PR DESCRIPTION
## Что
Правки автора в ядрах **8H.3** и **8N.3** (`!!core_v8H.md` / `!!core_v8N.md`):
- Подзаголовок логотипа разбит на шаблонные строки `{LIVE_SPECS_DATE}` / `{HOST_MODEL}` / `{LOAD_MODE}` (как в остальных редакциях).
- Убраны устаревшие `-ALPHA` (шапка меню + пункт «Что нового»).
- Обновлены даты `last_verified` и `DEADLINE STATUS` → 2026-06-27.
- Box-drawing логотип **сохранён** намеренно (в этих редакциях рендерится нормально).

## Почему
Эти правки лежали **незакоммиченными** в рабочей копии и не попали в архивы 8.3.8 — поэтому при скачивании был виден старый логотип.

## Проверки
Чистый UTF-8, без BOM, 0 mojibake. Архивы `p2p-high-8H.3.zip` / `p2p-normal-8N.3.zip` будут пересобраны и перезалиты на релиз v8.3.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)