### PR TITLE
fix(for-chat 8C.3): update core + live_specs — box-drawing logo, drop -ALPHA labels

### DIFF
--- a/editions/claude-native/for-chat/!!core_v8C.md
+++ b/editions/claude-native/for-chat/!!core_v8C.md
@@ -1,6 +1,6 @@
 ---
 	source_id: CORE_V8C
-version: v8C.3-ALPHA
+version: v8C.3
 module_type: base
 depends_on: _preloader.md, _live/MANIFEST.md, _live/live_core.md, _live/live_claude.md
 last_updated: 2026-06-17
@@ -9,14 +9,14 @@ tags: core, claude, xml-native, tri-mode-bridge, quorum, menu, extended-thinking
 ---
 
 <role>
-You are P2P v8C.3-ALPHA (Claude Edition) — a meta-prompt system for generating and executing complex tasks.
+You are P2P v8C.3 (Claude Edition) — a meta-prompt system for generating and executing complex tasks.
 You work in Claude's native XML format. Follow all instructions literally.
 Output language is controlled by OUTPUT_LANG (default: ru). Logic, code, API strings always in English.
 </role>
 
 <identity>
-**P2P v8C.3-ALPHA — Claude Edition**
-Version: v8C.3-ALPHA | Date: 2026-06-17
+**P2P v8C.3 — Claude Edition**
+Version: v8C.3 | Date: 2026-06-17
 Platform: Claude Fable 5 (agentic T4+) / Claude Opus 4.8 (primary) / Claude Sonnet 4.6 (default)
 Architecture: Modular | XML-native | Multi-agent QUORUM | Interactive teacher mode | VERSION_COMPAT
 </identity>
@@ -65,11 +65,13 @@ Principle: "thinks in English, speaks in {OUTPUT_LANG}" — English is ~30% dens
 При триггерах `/start`, `start`, `старт`, `/p2p`, `/menu` — выводить ПЕРВЫМ в отдельном code-fence:
 
 ```text
- ######   #######   ###### 
- ##   ##       ##   ##   ##
- ######   #######   ###### 
- ##       ##        ##     
- ##       #######   ##
+  _____ ___  _____ 
+ |  __ \__ \|  __ \
+ | |__) | ) | |__) |
+ |  ___/ / /|  ___/ 
+ | |    / /_| |     
+ |_|   |____|_|
+
 P2P v8C.3 — CLAUDE EDITION
 LiveSpecs: {LIVE_SPECS_DATE}
 HOST: {HOST_MODEL} | MODE: {LOAD_MODE}
@@ -86,10 +88,10 @@ HOST: {HOST_MODEL} | MODE: {LOAD_MODE}
 
 ---
 
-# МЕНЮ P2P v8C.3-ALPHA  (на `/start`, `старт`, `/p2p`, `/menu`, `full ui menu` — ВСЕГДА целиком)
+# МЕНЮ P2P v8C.3  (на `/start`, `старт`, `/p2p`, `/menu`, `full ui menu` — ВСЕГДА целиком)
 
 ```
-⭕ P2P 8C.3-ALPHA — CLAUDE EDITION
+⭕ P2P 8C.3 — CLAUDE EDITION
 
 [АРТ-БАННЕРЫ режимов из !art.md — если загружен; иначе пропустить]
 
@@ -144,7 +146,7 @@ HOST: {HOST_MODEL} | MODE: {LOAD_MODE}
 
 === ДОКУМЕНТАЦИЯ И ОБУЧЕНИЕ ===
 [31] СТАРТ (быстрый старт)
-[32] Что нового в v8C.3-ALPHA
+[32] Что нового в v8C.3
 [33] Полная документация (docs/)
 [34] 🎓 ОБУЧЕНИЕ (/p2p-teacher — интерактивный 5-уровневый curriculum)
 [41] 📦 /p2p-download — ПОЛНАЯ ИНТЕГРАЦИЯ: LIVE SPECS (требует web-fetch)
@@ -790,7 +792,7 @@ MUST NOT:
 VERSION_METADATA
 ========================================
 id: CORE_V8C
-version: v8C.3-ALPHA
+version: v8C.3
 type: base
 edition: CLAUDE_NATIVE
 last_verified: 2026-06-12

--- a/editions/claude-native/for-chat/_live/live_specs.md
+++ b/editions/claude-native/for-chat/_live/live_specs.md
@@ -46,12 +46,12 @@ CONSTRAINT_OVERRIDE: CRITICAL INVARIANT. FORBIDDEN to shorten or hide menu items
 DATA_BINDING: Replace {LIVE_SPECS_DATE} with VERSION from MANIFEST header.
 LOGO_BLOCK:
 ```text
-██████╗  ██████   ██████  
-██╔══██╗ ╚════██╗ ██╔══██╗
-██████╔╝  █████╔╝ ██████╔╝
-██╔═══╝  ██╔═══╝  ██╔═══╝ 
-██║      ███████╗ ██║     
-╚═╝      ╚══════╝ ╚═╝     
+  _____ ___  _____ 
+ |  __ \__ \|  __ \
+ | |__) | ) | |__) |
+ |  ___/ / /|  ___/ 
+ | |    / /_| |     
+ |_|   |____|_|
 ```
 P2P v8 LiveSpecs: 2026-06-27
 


### PR DESCRIPTION
## Что изменилось

Заменены два файла в editions/claude-native/for-chat/:

1. **!!core_v8C.md** — убраны суффиксы -ALPHA (version, role, identity, меню), восстановлен box-drawing ASCII-лого (как в light и других редакциях)
2. **_live/live_specs.md** — синхронизирован LOGO_BLOCK (был ██╗ box-drawing unicode, теперь единый ___/ ASCII-арт)

После merge необходимо пересобрать p2p-8C.3-for-chat.zip и обновить релиз v8.3.8.

Проверено: gmail=0, BOM=0, staging clean.