### PR TITLE
fix(for-chat 8C.3): correct YAML frontmatter — add opening --- remove tab before source_id

### DIFF
--- a/editions/claude-native/for-chat/!!core_v8C.md
+++ b/editions/claude-native/for-chat/!!core_v8C.md
@@ -1,4 +1,5 @@
-	source_id: CORE_V8C
+---
+source_id: CORE_V8C
 version: v8C.3
 module_type: base
 depends_on: _preloader.md, _live/MANIFEST.md, _live/live_core.md, _live/live_claude.md


### PR DESCRIPTION
## Проблема

На GitHub в editions/claude-native/for-chat/!!core_v8C.md была некорректная YAML-шапка:
- **Отсутствовало** открывающее --- (первая строка сразу начиналась с \tsource_id)
- Перед source_id стоял **таб** (невалидный YAML-отступ)

В итоге парсер frontmatter воспринимал файл как не имеющий YAML-блока.

## Фикс

- Добавлено открывающее --- (строка 1)
- Убран таб перед source_id
- Закрывающее --- (строка 9) было на месте — не тронуто

Изменён: 1 файл, 1 строка (добавлено ---).