### PR TITLE
hotfix v8.4.2 — fix plugin YAML frontmatter (Claude Code failed to load p2p-v8c3 commands)

### DIFF
--- a/editions/claude-native/CHANGELOG.md
+++ b/editions/claude-native/CHANGELOG.md
@@ -9,6 +9,14 @@ tags: docs, changelog, v8c3, alpha
 
 # P2P v8C.3 — CHANGELOG
 
+## [HOTFIX · 8.4.2 · 2026-07-06] Claude Code не грузил команды плагина (битый YAML frontmatter)
+**Симптом:** после 8.4.1 в Claude Code исчезли все команды `p2p-v8c3` (в Cowork работали). 
+**Причина:** в `skills/p2p/SKILL.md` описание содержало `(core.md): no task` — двоеточие+пробел ломает
+строгий YAML-парсер Code (Cowork парсит мягко → там работало). Битый **скилл** роняет загрузку всего плагина.
+**Фикс:** убран `: ` из описания `SKILL.md`; заодно вычищены унаследованные дефекты — `commands/p2p-karpathy.md`
+(`approach:` → `approach —`, кавычки на `argument-hint`), `commands/p2p-download.md` (добавлен `description`).
+Проверено строгим YAML-парсером: 12 команд + 8 скиллов — 0 ошибок. Bump `p2p-v8c3 8.4.1 → 8.4.2`.
+
 > v8C.2 → v8C.3 changes only.  
 > For v8C.1 → v8C.2 history see the v8C.2 release docs.
 

--- a/editions/claude-native/plugin/.claude-plugin/plugin.json
+++ b/editions/claude-native/plugin/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "p2p-v8c3",
-  "displayName": "P2P 8.4.1-C — Claude Native",
-  "version": "8.4.1",
+  "displayName": "P2P 8.4.2-C — Claude Native",
+  "version": "8.4.2",
   "description": "Meta-prompt system for Claude Fable 5 / Opus 4.8 / Sonnet 4.6. 8 QUORUM agents, 11 /p2p-* commands, XML-native, SCOPE.HELM, interactive teacher mode.",
   "author": {
     "name": "P2P Project"

--- a/editions/claude-native/plugin/.claude/commands/p2p-download.md
+++ b/editions/claude-native/plugin/.claude/commands/p2p-download.md
@@ -1,4 +1,5 @@
 ---
+description: "/p2p-download — fetch the latest LIVE SPECS from the gist and refresh the session context."
 source_id: CMD_DOWNLOAD_V8C
 version: v8C.3
 module_type: command

--- a/editions/claude-native/plugin/.claude/commands/p2p-karpathy.md
+++ b/editions/claude-native/plugin/.claude/commands/p2p-karpathy.md
@@ -1,6 +1,6 @@
 ---
-description: P2P Karpathy Coding Mode — precision behavioral constraints for surgical code edits. Minimalist approach: Template M + PRE_CODE_DECLARATION. Composable with agentic (M+R) and IDE (M+I) templates.
-argument-hint: [task description | file:path function:name]
+description: P2P Karpathy Coding Mode — precision behavioral constraints for surgical code edits. Minimalist approach — Template M + PRE_CODE_DECLARATION. Composable with agentic (M+R) and IDE (M+I) templates.
+argument-hint: "[task description | file:path function:name]"
 ---
 
 Активируй skill `p2p`. Запусти **Karpathy Coding Mode** (Template M) для задачи: $ARGUMENTS

--- a/editions/claude-native/plugin/.claude/skills/p2p/SKILL.md
+++ b/editions/claude-native/plugin/.claude/skills/p2p/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: p2p
-description: P2P v8C.3 — main Skill entry point of the Prompt-to-Prompt meta-prompt system for Claude. Use when the user types /p2p, /start, старт, /menu, or asks to build/generate/optimize a prompt, run a QUORUM multi-agent review, SCOPE.HELM scoping, or any /p2p-* workflow. Loads the dispatcher (core.md): no task → menu; a task → auto-routes (complex → QUORUM via native sub-agents, simple → co-pilot). Entry point and main menu for the P2P system. Not for the interactive course (use p2p-teacher).
+description: P2P v8C.3 — main Skill entry point of the Prompt-to-Prompt meta-prompt system for Claude. Use when the user types /p2p, /start, старт, /menu, or asks to build/generate/optimize a prompt, run a QUORUM multi-agent review, SCOPE.HELM scoping, or any /p2p-* workflow. Loads the dispatcher (core.md) — no task shows the menu, a task auto-routes (complex → QUORUM via native sub-agents, simple → co-pilot). Entry point and main menu for the P2P system. Not for the interactive course (use p2p-teacher).
 source_id: SKILL_V8C
 version: v8C.3
 module_type: skill


### PR DESCRIPTION
## Русский
**Хотфикс 8.4.2.** После 8.4.1 в Claude Code исчезли все команды `p2p-v8c3` (в Cowork работали).

**Причина:** в `skills/p2p/SKILL.md` описание содержало `(core.md): no task` — двоеточие+пробел ломает строгий YAML-парсер Claude Code; битый скилл роняет загрузку всего плагина. Cowork парсит YAML мягко, поэтому там работало.

**Фикс:** убран `: ` из `SKILL.md`; вычищены унаследованные дефекты `p2p-karpathy.md` (YAML) и `p2p-download.md` (нет description). Строгий парсер: 12 команд + 8 скиллов — 0 ошибок. Bump `p2p-v8c3 → 8.4.2`.

## English
**Hotfix 8.4.2.** After 8.4.1 all `p2p-v8c3` commands vanished in Claude Code (worked in Cowork).

**Cause:** `skills/p2p/SKILL.md` description contained `(core.md): no task` — a colon+space that breaks Claude Code's strict YAML parser; a broken skill aborts the whole plugin load. Cowork parses leniently, so it worked there.

**Fix:** removed the `: ` from `SKILL.md`; also cleaned inherited defects in `p2p-karpathy.md` (YAML) and `p2p-download.md` (missing description). Strict parser: 12 commands + 8 skills, 0 errors. Bump `p2p-v8c3 → 8.4.2`.