### PR TITLE
release: p2p-v8c3 v8.4.3 — slash commands fix (restore v8.3.9 SKILL.md+p2p.md)

### DIFF
--- a/editions/claude-native/plugin/.claude-plugin/plugin.json
+++ b/editions/claude-native/plugin/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "p2p-v8c3",
-  "displayName": "P2P 8.4.2-C — Claude Native",
-  "version": "8.4.2",
+  "displayName": "P2P 8.4.3-C — Claude Native",
+  "version": "8.4.3",
   "description": "Meta-prompt system for Claude Fable 5 / Opus 4.8 / Sonnet 4.6. 8 QUORUM agents, 11 /p2p-* commands, XML-native, SCOPE.HELM, interactive teacher mode.",
   "author": {
     "name": "P2P Project"

--- a/editions/claude-native/plugin/.claude/commands/p2p.md
+++ b/editions/claude-native/plugin/.claude/commands/p2p.md
@@ -1,51 +1,24 @@
 ---
-description: "/p2p — main entry point. No task → menu. With a task → auto-route (complex → QUORUM, simple → co-pilot)."
-argument-hint: "[задача | start | menu]"
+description: "/p2p — main entry point. Show menu, detect environment, initialize session."
+argument-hint: "[start|menu]"
 source_id: CMD_P2P_V8C
 version: v8C.3
 module_type: command
-last_updated: 2026-07-05
-scope: /p2p — smart entry. Loads the dispatcher (skills/p2p/core.md) and either shows the menu or auto-orchestrates the given task.
+last_updated: 2026-06-12
+scope: /p2p — main entry point. Show menu, detect environment, initialize session.
 ---
-# /p2p — Главная Команда (нативный диспетчер)
+# /p2p — Главная Команда
 
-**Что делает:** единая точка входа P2P. Ведёт себя как загруженная система в чате —
-меню при пустом входе, авто-оркестрация при задаче.
+**Что делает:** Показывает главное меню P2P v8C.3 и инициализирует сессию.
 
-## Алгоритм (ОБЯЗАТЕЛЬНО выполнять по шагам)
+**Алгоритм:**
+1. Определить среду (TRI_MODE_BRIDGE v3)
+2. Загрузить p2p.config.md если есть
+3. Показать меню (34 пункта)
+4. Вывести: `[P2P v8C.3 | Среда: {СРЕДА} | Guardian: {ON/OFF}]`
 
-**Шаг 0 — поднять диспетчер (единый источник истины, НЕ дублировать логику):**
-Прочитать и активировать бандл P2P: `skills/p2p/core.md` — §МЕНЮ, §PILOT MODE, §SIR SCANNER,
-§QUORUM (+ BUDGET DECLARATION), §DEEP_THINK_VALUE_GATE, §ROUTING MEMORY, правило «При Tier ≥ 3 → QUORUM»
-(LoadScore/Tier) — и `skills/p2p/db.md` (техники, агенты, G-ошибки). Определить среду
-(TRI_MODE_BRIDGE v3), подхватить `skills/p2p/p2p.config.md` если есть.
+**Использование:** `/p2p` или команда `СТАРТ`
 
-**Шаг 1 — маршрут по аргументу:**
-
-- **Аргумент пуст ИЛИ `start`/`старт`/`menu`/`меню`** →
-  вывести STARTUP_LOGO + меню [0-40] целиком + баннер `[P2P v8C.3 | Среда: {СРЕДА} | Guardian: {ON/OFF}]`.
-  Ждать выбора.
-
-- **Аргумент = ЗАДАЧА** → НЕ показывать меню, а сразу **авто-оркестрация** (как for-chat):
-  1. SIR Scanner — если шум/гомоглифы >15%, очистить и восстановить интент.
-  2. Посчитать `LoadScore` → определить `Tier 0-4` (§TIER_SYSTEM).
-  3. **`Tier ≥ 3`** → запустить **QUORUM** (скилл `p2p-quorum` / `.claude/agents/*` через Task tool;
-     потребовать BUDGET DECLARATION; HELIOS — финальный синтез). Реальные sub-агенты (нативно Claude Code).
-  4. **`Tier ≤ 2`** → **co-pilot**: молча выбрать технику/модель/effort
-     (DEEP_THINK_VALUE_GATE + routing), при новичке/неясной цели — короткое уточнение; сгенерировать промпт.
-  5. Применить синтаксис `TARGET_MODEL` (не HOST), OUTPUT SANITIZATION, ZERO_STATE_IMMUNITY.
-
-**Шаг 2 — язык вывода:** по `OUTPUT_LANG` (default ru), техническая логика — на английском.
-
-## Использование
-```
-/p2p                      → меню (инициализация сессии)
-/p2p сделай промпт для X   → авто: простая → co-pilot, сложная → QUORUM
-СТАРТ                      → то же меню (ловится скиллом p2p по триггеру)
-```
-
-> ⚠️ Полный функционал Claude Code сохранён: QUORUM идёт через нативные sub-агенты (Task tool),
-> а не симуляцию. Команда — тонкий триггер; вся логика в `skills/p2p/core.md` (не копировать сюда).
 
 ========================================
 VERSION_METADATA
@@ -54,7 +27,6 @@ id: CMD_P2P_V8C
 version: v8C.3
 type: command
 edition: CLAUDE_NATIVE
-last_verified: 2026-07-05
-changelog: wired to dispatcher (skills/p2p/core.md) — empty→menu, task→auto-route (Tier≥3 QUORUM else co-pilot)
+last_verified: 2026-06-12
 invariants_passed: [I1_yaml, I2_api_strings, I3_deadlines, I4_g_errors, I5_version_metadata, I6_xml_native, I7_agents_8]
 ========================================

--- a/editions/claude-native/plugin/.claude/skills/p2p/SKILL.md
+++ b/editions/claude-native/plugin/.claude/skills/p2p/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: p2p
-description: P2P v8C.3 — main Skill entry point of the Prompt-to-Prompt meta-prompt system for Claude. Use when the user types /p2p, /start, старт, /menu, or asks to build/generate/optimize a prompt, run a QUORUM multi-agent review, SCOPE.HELM scoping, or any /p2p-* workflow. Loads the dispatcher (core.md) — no task shows the menu, a task auto-routes (complex → QUORUM via native sub-agents, simple → co-pilot). Entry point and main menu for the P2P system. Not for the interactive course (use p2p-teacher).
+description: P2P v8C.3 — main Skill entry point of the Prompt-to-Prompt meta-prompt system for Claude. Use when the user types /p2p, /start, старт, or /menu, or asks to build/generate/optimize a prompt, run a QUORUM multi-agent review, SCOPE.HELM scoping, or any /p2p-* workflow. Entry point and main menu for the P2P system. Not for the interactive course (use p2p-teacher).
 source_id: SKILL_V8C
 version: v8C.3
 module_type: skill
@@ -24,18 +24,6 @@ P2P v8C.3 — мета-промпт система для:
 - Управления большими задачами (SCOPE.HELM)
 - Cross-model адаптации (Translation Layer для 8 LLM)
 - **NEW:** Интерактивного обучения системе (`/p2p-teacher`)
-
-## Поведение — ДИСПЕТЧЕР (обязательно, единый источник истины)
-
-При активации: поднять бандл `core.md` (PILOT_MODE, TIER_SYSTEM + LoadScore, SIR,
-DEEP_THINK_VALUE_GATE, QUORUM) + `db.md`. Логику НЕ дублировать здесь — только запустить.
-
-- **Нет задачи / `старт`/`menu`** → показать STARTUP_LOGO + меню [0-40] + баннер. Ждать выбор.
-- **Есть задача** → авто-оркестрация (как for-chat): SIR-скан → `LoadScore`→`Tier` →
-  `Tier ≥ 3` **QUORUM** (нативные sub-агенты `.claude/agents/*` в Code; в Cowork — скилл `p2p-quorum`),
-  `Tier ≤ 2` **co-pilot** (молча техника/модель/effort). Вывод в синтаксисе `TARGET_MODEL`.
-
-> Полный функционал сохранён: в Claude Code QUORUM — реальные параллельные sub-агенты, не симуляция.
 
 ## Команды (11)
 


### PR DESCRIPTION
## Summary

- Restores `skills/p2p/SKILL.md` and `commands/p2p.md` to their **v8.3.9 content** (last known-working version)
- v8.4.1 rewrote both files (dispatcher wiring); v8.4.2 fixed the visible `: ` YAML issue but runtime loading still failed — slash commands (`/p2p-v8c3:*`) did not appear in Claude Code slash menu
- Reverting to v8.3.9 guarantees the plugin loads correctly at runtime
- Bumps `p2p-v8c3` → **8.4.3**

## Changes

| File | Change |
|---|---|
| `plugin.json` | version 8.4.2 → **8.4.3**, displayName updated |
| `skills/p2p/SKILL.md` | Restored to v8.3.9 (shorter description, no dispatcher reference) |
| `commands/p2p.md` | Restored to v8.3.9 (simple menu, 32 lines vs 61) |

## Test plan

- [ ] After merge: run `/plugin marketplace update P2P-4PDA-edition` in Claude Code
- [ ] Type `/p2p-v8c3:` — all commands should appear in slash menu
- [ ] `/p2p-v8c3:p2p-quorum` should be invocable

🤖 Generated with [Claude Code](https://claude.com/claude-code)