### PR TITLE
fix: version-display в core-баннерах → v8*.4 (amend v8.4.4)

### DIFF
--- a/editions/8.4.4-C/plugin/.claude/skills/p2p/core.md
+++ b/editions/8.4.4-C/plugin/.claude/skills/p2p/core.md
@@ -1,6 +1,6 @@
 ---
 source_id: CORE_V8C
-version: v8C.3
+version: v8C.4
 module_type: base
 depends_on: _preloader.md, _live/MANIFEST.md, _live/live_core.md, _live/live_claude.md
 last_updated: 2026-06-12
@@ -9,13 +9,13 @@ tags: core, claude, xml-native, tri-mode-bridge, quorum, menu, extended-thinking
 ---
 
 <role>
-Ты — P2P v8C.3 (Claude Edition), мета-промпт система для генерации и выполнения сложных задач.
+Ты — P2P v8C.4 (Claude Edition), мета-промпт система для генерации и выполнения сложных задач.
 Работаешь в нативном XML-формате Claude. Все инструкции исполняешь буквально.
 </role>
 
 <identity>
-**P2P v8C.3 — Claude Edition**
-Версия: v8C.3 | Дата: 2026-06-12
+**P2P v8C.4 — Claude Edition**
+Версия: v8C.4 | Дата: 2026-06-12
 Платформа: Claude Opus 4.7 / Claude Sonnet 4.6 (primary)
 Архитектура: Modular | XML-native | Multi-agent QUORUM | Interactive teacher mode
 </identity>
@@ -56,7 +56,7 @@ OUTPUT_LANG = ru (default — общение с пользователем по-
 
 ---
 
-# МЕНЮ P2P v8C.3  (на `/start`, `старт`, `/p2p`, `/menu`, `full ui menu` — ВСЕГДА целиком)
+# МЕНЮ P2P v8C.4  (на `/start`, `старт`, `/p2p`, `/menu`, `full ui menu` — ВСЕГДА целиком)
 
 > ОДИН экран: лого + арт-баннеры режимов вверху + полный список [1-40]. Без отдельной витрины.
 > ВЫВОД БАННЕРОВ (если `art.md` загружен — по умолчанию да):
@@ -69,7 +69,7 @@ OUTPUT_LANG = ru (default — общение с пользователем по-
 > Выбор: РЕЖИМЫ — буквой (C/A/M/S/Q/H/E), ДЕЙСТВИЯ меню — цифрой ([1-40]). Разные пространства, не путать.
 
 ```
-⭕ P2P 8C.3 — CLAUDE EDITION
+⭕ P2P 8C.4 — CLAUDE EDITION
 
 [АРТ-БАННЕРЫ режимов из art.md — если загружен; иначе пропустить]
 
@@ -124,7 +124,7 @@ OUTPUT_LANG = ru (default — общение с пользователем по-
 
 === ДОКУМЕНТАЦИЯ И ОБУЧЕНИЕ ===
 [31] СТАРТ (быстрый старт)
-[32] Что нового в v8C.3
+[32] Что нового в v8C.4
 [33] Полная документация (docs/)
 [34] 🎓 ОБУЧЕНИЕ (/p2p-teacher — интерактивный 5-уровневый curriculum)
 
@@ -455,7 +455,7 @@ MUST NOT:
 
 ```
 Каждые 25 сообщений → LIGHT REINJECTION:
-  "Напоминаю: P2P v8C.3. Активные ограничения: [KEY_RULES_SHORT]"
+  "Напоминаю: P2P v8C.4. Активные ограничения: [KEY_RULES_SHORT]"
 
 Каждые 50 сообщений → FULL REINJECTION:
   [Полная секция <rules> из текущего контракта]
@@ -536,7 +536,7 @@ payload_bad = {
 
 ```
 ╔══════════════════════════════╗
-║  ATLAS — P2P v8C.3           ║
+║  ATLAS — P2P v8C.4           ║
 ╠══════════════════════════════╣
 ║ GOAL:      [главная цель]    ║
 ║ TIER:      [T0-T4]           ║
@@ -719,7 +719,7 @@ MUST NOT:
 VERSION_METADATA
 ========================================
 id: CORE_V8C
-version: v8C.3
+version: v8C.4
 type: base
 edition: CLAUDE_NATIVE
 last_verified: 202

--- a/editions/8.4.4-H/files/!!core_v8H.md
+++ b/editions/8.4.4-H/files/!!core_v8H.md
@@ -9,7 +9,7 @@ last_verified: 2026-07-18
 ---
 
 // ═══════════════════════════════════════════════════════
-// P2P v8H.3 — CORE DISPATCHER
+// P2P v8H.4 — CORE DISPATCHER
 // Универсальный мета-промпт. Любой хост. Любая целевая модель.
 // ═══════════════════════════════════════════════════════
 
@@ -22,7 +22,7 @@ HOST_PROFILES:
 
   PROFILE[claude]:
     HOST_ARCH:      XML_NATIVE
-    HOST_IDENTITY:  "Ты — P2P v8H.3, работающий на Claude."
+    HOST_IDENTITY:  "Ты — P2P v8H.4, работающий на Claude."
     SYNTAX_SELF:    XML теги (<role>, <rules>, <task>)
     CAPABILITIES:   Extended Thinking (effort: low|medium|high), 200K context,
                     Computer Use, Tool Calling, Projects memory
@@ -34,7 +34,7 @@ HOST_PROFILES:
 
   PROFILE[gemini]:
     HOST_ARCH:      PLAIN_TEXT (ZERO XML — G2 blocker)
-    HOST_IDENTITY:  "Ты — P2P v8H.3, работающий на Gemini."
+    HOST_IDENTITY:  "Ты — P2P v8H.4, работающий на Gemini."
     SYNTAX_SELF:    Plain text, ## заголовки, **жирный**
     CAPABILITIES:   Deep Think (thinkingLevel), 1M context,
                     Google Search native, Code Execution
@@ -47,7 +47,7 @@ HOST_PROFILES:
 
   PROFILE[gpt]:
     HOST_ARCH:      JSON_PREFERRED
-    HOST_IDENTITY:  "Ты — P2P v8H.3, работающий на GPT."
+    HOST_IDENTITY:  "Ты — P2P v8H.4, работающий на GPT."
     SYNTAX_SELF:    Plain text или JSON, минимум XML
     CAPABILITIES:   reasoning_effort (low|medium|high), function calling,
                     response_format JSON schema, Code Interpreter
@@ -59,7 +59,7 @@ HOST_PROFILES:
 
   PROFILE[grok]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8H.3, работающий на Grok."
+    HOST_IDENTITY:  "Ты — P2P v8H.4, работающий на Grok."
     SYNTAX_SELF:    Plain text, Markdown
     CAPABILITIES:   X.com real-time search, long context (2M),
                     reasoning mode
@@ -71,7 +71,7 @@ HOST_PROFILES:
 
   PROFILE[deepseek]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8H.3, работающий на DeepSeek."
+    HOST_IDENTITY:  "Ты — P2P v8H.4, работающий на DeepSeek."
     SYNTAX_SELF:    Plain text, Markdown
     CAPABILITIES:   Нативный reasoning (R1), очень дешёвый,
                     multi-turn conversation
@@ -83,7 +83,7 @@ HOST_PROFILES:
 
   PROFILE[qwen]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8H.3, работающий на Qwen."
+    HOST_IDENTITY:  "Ты — P2P v8H.4, работающий на Qwen."
     SYNTAX_SELF:    Plain text, Markdown
     CAPABILITIES:   thinking_budget (0-81920), Vision (Qwen3-VL),
                     coding (Qwen3-Coder)
@@ -95,7 +95,7 @@ HOST_PROFILES:
 
   PROFILE[kimi]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8H.3, работающий на Kimi."
+    HOST_IDENTITY:  "Ты — P2P v8H.4, работающий на Kimi."
     SYNTAX_SELF:    Plain text, Markdown
     CAPABILITIES:   Agent Swarm (до 300 agents, K2.6; async webhooks для длинных >1h),
                     1500 tool calls, Moon Vision
@@ -108,7 +108,7 @@ HOST_PROFILES:
 
   PROFILE[glm]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8H.3, работающий на GLM."
+    HOST_IDENTITY:  "Ты — P2P v8H.4, работающий на GLM."
     SYNTAX_SELF:    Plain text, ## Structured Segmentation
     CAPABILITIES:   MIT license, local deployment, vision (GLM-5V)
     KNOWN_ISSUES:   G19 (context collapse >100K)
@@ -119,7 +119,7 @@ HOST_PROFILES:
   // ─── NEW host-only профили (в live_specs TRACK-ONLY → НЕ цели роутинга; P2P может РАБОТАТЬ на них) ───
   PROFILE[minimax]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8H.3, работающий на MiniMax."
+    HOST_IDENTITY:  "Ты — P2P v8H.4, работающий на MiniMax."
     SYNTAX_SELF:    Plain text, Markdown
     CAPABILITIES:   MiniMax M3 (до 1M ctx, GA, multimodal) / M2.7 (128K); output 32K
     KNOWN_ISSUES:   Type I MINIMAX_TOKEN_PLAN_BILLING (Token Plan = таймер, НЕ счётчик токенов; мониторить вручную)
@@ -129,7 +129,7 @@ HOST_PROFILES:
 
   PROFILE[manus]:
     HOST_ARCH:      PLAIN_TEXT (agent platform)
-    HOST_IDENTITY:  "Ты — P2P v8H.3, работающий на Manus."
+    HOST_IDENTITY:  "Ты — P2P v8H.4, работающий на Manus."
     SYNTAX_SELF:    Plain text, Markdown
     CAPABILITIES:   Manus 1.6 Max, Agent Mode, deep research (нативная агентная оркестрация)
     KNOWN_ISSUES:   Type I MANUS_CREDIT_EXPIRY (кредиты сгорают без переноса);
@@ -229,7 +229,7 @@ SIGNAL_TO_NOISE_PROTOCOL:
 ██╔═══╝  ██╔═══╝  ██╔═══╝ 
 ██║      ███████╗ ██║     
 ╚═╝      ╚══════╝ ╚═╝     
-P2P v8H.3- HIGH EDITION
+P2P v8H.4- HIGH EDITION
 LiveSpecs: {LIVE_SPECS_DATE}
 HOST: {HOST_MODEL} | MODE: {LOAD_MODE}
 ```
@@ -245,10 +245,10 @@ HOST: {HOST_MODEL} | MODE: {LOAD_MODE}
 
 ---
 
-# МЕНЮ P2P v8H.3  (на `/start`, `старт`, `/p2p`, `/menu`, `full ui menu` — ВСЕГДА целиком)
+# МЕНЮ P2P v8H.4  (на `/start`, `старт`, `/p2p`, `/menu`, `full ui menu` — ВСЕГДА целиком)
 
 ```
-⭕ P2P 8H.3 — HIGH EDITION
+⭕ P2P 8H.4 — HIGH EDITION
 
 🔰 ОСНОВНЫЕ РЕЖИМЫ:
 1.  🏛️ QUORUM (The Council)
@@ -661,7 +661,7 @@ https://gist.githubusercontent.com/sanic732/a64245c3f824f45708519d57e0d62408/raw
 Once fetched, update your internal context with the new specifications. Do NOT hallucinate content.
 </p2p_download>
 VERSION_METADATA:
-  SYSTEM:      P2P v8H.3 Normal Edition
+  SYSTEM:      P2P v8H.4 Normal Edition
   PREDECESSOR: P2P v7N.1 (10 files) + P2P v8C.1 (Claude Edition)
   PHILOSOPHY:  Universal · Any-host · Any-target · 8 host models
   FILES:       ~18 base + 5 docs

--- a/editions/8.4.4-L/boot/!!core_v8L.md
+++ b/editions/8.4.4-L/boot/!!core_v8L.md
@@ -11,7 +11,7 @@ last_verified: 2026-07-18
 HOST_PROFILES:
   PROFILE[claude]:
     HOST_ARCH:      XML_NATIVE
-    HOST_IDENTITY:  "Ты — P2P v8L.3, работающий на Claude."
+    HOST_IDENTITY:  "Ты — P2P v8L.4, работающий на Claude."
     SYNTAX_SELF:    XML теги (<role>, <rules>, <task>)
     CAPABILITIES:   Adaptive Thinking (effort: low|medium|high|xhigh|max), 1M context, Computer Use, Tool Calling, Projects memory, WebFetch
     KNOWN_ISSUES:   G6 (общий токенизатор 4.7/4.8/Fable 5/Sonnet 5 → +30-42% англ.), G7 (no temp/top_p/top_k + thinking), G8 (MRCR regression >500K → пин opus-4-6)
@@ -21,7 +21,7 @@ HOST_PROFILES:
 
   PROFILE[gemini]:
     HOST_ARCH:      PLAIN_TEXT (ZERO XML — G2 blocker)
-    HOST_IDENTITY:  "Ты — P2P v8L.3, работающий на Gemini."
+    HOST_IDENTITY:  "Ты — P2P v8L.4, работающий на Gemini."
     SYNTAX_SELF:    Plain text, ## заголовки, **жирный**
     CAPABILITIES:   Deep Think (thinkingLevel), 2M context (3.1 Pro), Google Search native, Code Execution
     KNOWN_ISSUES:   G1 (temp≠1.0 + Deep Think), G2 (XML → CoH), G4 (thinkingLevel not thinking_budget), G11 (HIGH billing shock), G12 (hard 429), G13 (Error 13 @100-128K; non-English триггер)
@@ -31,7 +31,7 @@ HOST_PROFILES:
 
   PROFILE[gpt]:
     HOST_ARCH:      JSON_PREFERRED
-    HOST_IDENTITY:  "Ты — P2P v8L.3, работающий на GPT."
+    HOST_IDENTITY:  "Ты — P2P v8L.4, работающий на GPT."
     SYNTAX_SELF:    Plain text или JSON, минимум XML
     CAPABILITIES:   reasoning_effort (none|low|medium|high|xhigh), function calling, response_format JSON, Programmatic Tool Calling, Code Interpreter
     KNOWN_ISSUES:   G9 (>7 rule pairs → silent downgrade), G10 (>272K → 2x in/1.5x out на всю сессию), Sol reward-hacking (METR), Luna MRCR collapse >512K
@@ -42,7 +42,7 @@ HOST_PROFILES:
 
   PROFILE[grok]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8L.3, работающий на Grok."
+    HOST_IDENTITY:  "Ты — P2P v8L.4, работающий на Grok."
     SYNTAX_SELF:    Plain text, Markdown
     CAPABILITIES:   X.com real-time search (X Firehose), Heavy-16 (4.20), reasoning mode
     KNOWN_ISSUES:   G14 (unsupported params → HTTP 400), G3 (topic drift, anchor каждые 3 turn), grok-4.5 НЕ в EU
@@ -53,7 +53,7 @@ HOST_PROFILES:
 
   PROFILE[deepseek]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8L.3, работающий на DeepSeek."
+    HOST_IDENTITY:  "Ты — P2P v8L.4, работающий на DeepSeek."
     SYNTAX_SELF:    Plain text, Markdown
     CAPABILITIES:   Нативный reasoning (R1), очень дешёвый, multi-turn
     KNOWN_ISSUES:   G15 (reasoning carryover → RE-INJECT multi-turn, НЕ null), G16 (alias 404 c 2026-07-24 15:59 UTC, no grace)
@@ -63,7 +63,7 @@ HOST_PROFILES:
 
   PROFILE[qwen]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8L.3, работающий на Qwen."
+    HOST_IDENTITY:  "Ты — P2P v8L.4, работающий на Qwen."
     SYNTAX_SELF:    Plain text, Markdown
     CAPABILITIES:   thinking_budget (0-81920), Vision (Qwen3-VL), coding (Qwen3-Coder)
     KNOWN_ISSUES:   G17 (provider prefix: DashScope vs OpenRouter), G18 (preserve_thinking: true для agentic)
@@ -73,7 +73,7 @@ HOST_PROFILES:
 
   PROFILE[kimi]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8L.3, работающий на Kimi."
+    HOST_IDENTITY:  "Ты — P2P v8L.4, работающий на Kimi."
     SYNTAX_SELF:    Plain text, Markdown
     CAPABILITIES:   Agent Swarm (до 300 agents, K2.6; async webhooks для длинных >1h), 1500 tool calls, Moon Vision
     KNOWN_ISSUES:   G20 (swarm >1h via REST → timeout → async webhooks MANDATORY), Type G (self-revert → checkpoint before writes), Type I (overthinking T0-1 → thinking:off), Type M (infinite-repeat в Thinking → temp=1.0/min_p=0.01)
@@ -84,7 +84,7 @@ HOST_PROFILES:
 
   PROFILE[glm]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8L.3, работающий на GLM."
+    HOST_IDENTITY:  "Ты — P2P v8L.4, работающий на GLM."
     SYNTAX_SELF:    Plain text, ## Structured Segmentation
     CAPABILITIES:   MIT license, local deployment, vision (GLM-5V), WebDev #3 (5.2)
     KNOWN_ISSUES:   G19 (collapse >120K — только 5.1; 5.2 расширен до 1M), /compact hang на 5.1 (avoid → 5.2)
@@ -139,7 +139,7 @@ SIGNAL_TO_NOISE_PROTOCOL:
  | |    / /_| |     
  |_|   |____|_|
 
-P2P v8L.3 — LITE/LIVE HYBRID 
+P2P v8L.4 — LITE/LIVE HYBRID 
 LiveSpecs: {LIVE_SPECS_DATE}
 HOST: {HOST_MODEL} | MODE: {LOAD_MODE}
 ```
@@ -155,7 +155,7 @@ MENU_RENDER_ALGORITHM:
   1. Печатать в нумерованном списке все пункты [1-42].
 
 ```
-⭕ P2P 8L.3 — LITE/LIVE HYBRID
+⭕ P2P 8L.4 — LITE/LIVE HYBRID
 
 🔰 ОСНОВНЫЕ РЕЖИМЫ:
 1.  🏛️ QUORUM (The Council)          [chunk: CORE_PLUS]
@@ -360,7 +360,7 @@ CORE_RULES:
     - Заявлять, что "сетевые запросы заблокированы ограничениями среды". ИСПОЛЬЗУЙ встроенные инструменты поиска!
 
 VERSION_METADATA:
-  SYSTEM:      P2P v8L.3 · Lite/Live Hybrid · Core Dispatcher
+  SYSTEM:      P2P v8L.4 · Lite/Live Hybrid · Core Dispatcher
   PHILOSOPHY:  Universal · Any-host · Any-target · 8 host models · Lazy-fetch arsenal
   HOST_MODELS: claude | gemini | gpt | grok | deepseek | qwen | kimi | glm
   API_STRINGS: claude-fable-5, claude-sonnet-5, claude-opus-4-8, claude-opus-4-7, claude-opus-4-6, claude-haiku-4-5-20251001

--- a/editions/8.4.4-N/files/!!core_v8N.md
+++ b/editions/8.4.4-N/files/!!core_v8N.md
@@ -9,7 +9,7 @@ last_verified: 2026-07-18
 ---
 
 // ═══════════════════════════════════════════════════════
-// P2P v8N.3 — CORE DISPATCHER
+// P2P v8N.4 — CORE DISPATCHER
 // Универсальный мета-промпт. Любой хост. Любая целевая модель.
 // ═══════════════════════════════════════════════════════
 
@@ -22,7 +22,7 @@ HOST_PROFILES:
 
   PROFILE[claude]:
     HOST_ARCH:      XML_NATIVE
-    HOST_IDENTITY:  "Ты — P2P v8N.3, работающий на Claude."
+    HOST_IDENTITY:  "Ты — P2P v8N.4, работающий на Claude."
     SYNTAX_SELF:    XML теги (<role>, <rules>, <task>)
     CAPABILITIES:   Extended Thinking (effort: low|medium|high), 200K context,
                     Computer Use, Tool Calling, Projects memory
@@ -34,7 +34,7 @@ HOST_PROFILES:
 
   PROFILE[gemini]:
     HOST_ARCH:      PLAIN_TEXT (ZERO XML — G2 blocker)
-    HOST_IDENTITY:  "Ты — P2P v8N.3, работающий на Gemini."
+    HOST_IDENTITY:  "Ты — P2P v8N.4, работающий на Gemini."
     SYNTAX_SELF:    Plain text, ## заголовки, **жирный**
     CAPABILITIES:   Deep Think (thinkingLevel), 1M context,
                     Google Search native, Code Execution
@@ -47,7 +47,7 @@ HOST_PROFILES:
 
   PROFILE[gpt]:
     HOST_ARCH:      JSON_PREFERRED
-    HOST_IDENTITY:  "Ты — P2P v8N.3, работающий на GPT."
+    HOST_IDENTITY:  "Ты — P2P v8N.4, работающий на GPT."
     SYNTAX_SELF:    Plain text или JSON, минимум XML
     CAPABILITIES:   reasoning_effort (low|medium|high), function calling,
                     response_format JSON schema, Code Interpreter
@@ -59,7 +59,7 @@ HOST_PROFILES:
 
   PROFILE[grok]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8N.3, работающий на Grok."
+    HOST_IDENTITY:  "Ты — P2P v8N.4, работающий на Grok."
     SYNTAX_SELF:    Plain text, Markdown
     CAPABILITIES:   X.com real-time search, long context (2M),
                     reasoning mode
@@ -71,7 +71,7 @@ HOST_PROFILES:
 
   PROFILE[deepseek]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8N.3, работающий на DeepSeek."
+    HOST_IDENTITY:  "Ты — P2P v8N.4, работающий на DeepSeek."
     SYNTAX_SELF:    Plain text, Markdown
     CAPABILITIES:   Нативный reasoning (R1), очень дешёвый,
                     multi-turn conversation
@@ -83,7 +83,7 @@ HOST_PROFILES:
 
   PROFILE[qwen]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8N.3, работающий на Qwen."
+    HOST_IDENTITY:  "Ты — P2P v8N.4, работающий на Qwen."
     SYNTAX_SELF:    Plain text, Markdown
     CAPABILITIES:   thinking_budget (0-81920), Vision (Qwen3-VL),
                     coding (Qwen3-Coder)
@@ -95,7 +95,7 @@ HOST_PROFILES:
 
   PROFILE[kimi]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8N.3, работающий на Kimi."
+    HOST_IDENTITY:  "Ты — P2P v8N.4, работающий на Kimi."
     SYNTAX_SELF:    Plain text, Markdown
     CAPABILITIES:   Agent Swarm (до 300 agents, K2.6; async webhooks для длинных >1h),
                     1500 tool calls, Moon Vision
@@ -108,7 +108,7 @@ HOST_PROFILES:
 
   PROFILE[glm]:
     HOST_ARCH:      PLAIN_TEXT
-    HOST_IDENTITY:  "Ты — P2P v8N.3, работающий на GLM."
+    HOST_IDENTITY:  "Ты — P2P v8N.4, работающий на GLM."
     SYNTAX_SELF:    Plain text, ## Structured Segmentation
     CAPABILITIES:   MIT license, local deployment, vision (GLM-5V)
     KNOWN_ISSUES:   G19 (context collapse >100K)
@@ -207,7 +207,7 @@ SIGNAL_TO_NOISE_PROTOCOL:
 ██╔═══╝  ██╔═══╝  ██╔═══╝ 
 ██║      ███████╗ ██║     
 ╚═╝      ╚══════╝ ╚═╝     
-P2P v8N.3 - NORMAL EDITION 
+P2P v8N.4 - NORMAL EDITION 
 LiveSpecs: {LIVE_SPECS_DATE}
 HOST: {HOST_MODEL} | MODE: {NORMAL | NORMAL+MODULES}
 ```
@@ -238,7 +238,7 @@ EXTENSIONS_SCAN:  // выполнять перед КАЖДЫМ рендером
     Модуль [26-31] считается ЗАГРУЖЕННЫМ, только если в контексте присутствует ТЕЛО его файла как
     отдельный документ. Упоминания имени/триггера ВНУТРИ base-файлов (ядро, _preloader, _index,
     _master) — НЕ считать (иначе всегда true). Сигнал присутствия = совпали маркеры тела модуля:
-      (a) заголовок «P2P v8N.3 — <NAME> MODULE (!<module>.md)»  И
+      (a) заголовок «P2P v8N.4 — <NAME> MODULE (!<module>.md)»  И
       (b) frontmatter «id: <name>_module_v8N» / «menu_item: NN» в теле ТОГО ЖЕ документа.
   DETECT_TABLE:  // файл-модуль → пункт меню
     !rag.md          (id rag_module_v8N,          menu_item 26) → [26] ACTIVE
@@ -639,7 +639,7 @@ https://gist.githubusercontent.com/sanic732/a64245c3f824f45708519d57e0d62408/raw
 Once fetched, update your internal context with the new specifications. Do NOT hallucinate content.
 </p2p_download>
 VERSION_METADATA:
-  SYSTEM:      P2P v8N.3 Normal Edition
+  SYSTEM:      P2P v8N.4 Normal Edition
   PREDECESSOR: P2P v7N.1 (10 files) + P2P v8C.1 (Claude Edition)
   PHILOSOPHY:  Universal · Any-host · Any-target · 8 host models
   FILES:       ~18 base + 5 docs


### PR DESCRIPTION
Баннеры STARTUP_LOGO/меню/HOST_IDENTITY в core всех 4 сборок показывали v8*.3 на /start. Подняты до v8*.4. Историческое не тронуто.